### PR TITLE
Accept pre-compiled Pattern objects

### DIFF
--- a/pydantic/validators.py
+++ b/pydantic/validators.py
@@ -463,8 +463,13 @@ def any_class_validator(v: Any) -> Type[T]:
 
 
 def pattern_validator(v: Any) -> Pattern[str]:
+    if isinstance(v, Pattern):
+        return v
+
+    str_value = str_validator(v)
+
     try:
-        return re.compile(v)
+        return re.compile(str_value)
     except re.error:
         raise errors.PatternError()
 
@@ -478,7 +483,6 @@ class IfConfig:
         return any(getattr(config, name) not in {None, False} for name in self.config_attr_names)
 
 
-pattern_validators = [str_validator, pattern_validator]
 # order is important here, for example: bool is a subclass of int so has to come first, datetime before date same,
 # IPv4Interface before IPv4Address, etc
 _VALIDATORS: List[Tuple[AnyType, List[Any]]] = [
@@ -534,7 +538,7 @@ def find_validators(  # noqa: C901 (ignore complexity)
     if type_type == ForwardRef or type_type == TypeVar:
         return
     if type_ is Pattern:
-        yield from pattern_validators
+        yield pattern_validator
         return
     if is_callable_type(type_):
         yield callable_validator


### PR DESCRIPTION
Make pattern_validator() accept pre-compiled Pattern objects.

Resolves #1237.

<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://pydantic-docs.helpmanual.io/contributing/ for help on Contributing -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
* [ ] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
